### PR TITLE
Fixed generator name (its not the strategy name)

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ If you are new to jOOQ, I recommend to read the awesome [jOOQ documentation](htt
 
               <!-- Generator parameters -->
               <generator>
-                  <name>io.github.jklingsporn.vertx.jooq.async.generate.future.FutureAsyncGeneratorStrategy</name>
+                  <name>io.github.jklingsporn.vertx.jooq.async.generate.future.FutureAsyncVertxGenerator</name>
                   <database>
                       <name>org.jooq.util.mysql.MySQLDatabase</name>
                       <includes>.*</includes>


### PR DESCRIPTION
There's an error in the documentation, where the example POM snippet uses the strategy class name for the generator class. 

This causes an error  during build:

java.lang.ClassCastException: io.github.jklingsporn.vertx.jooq.async.generate.future.FutureAsyncGeneratorStrategy cannot be cast to org.jooq.util.Generator
