### PR TITLE
Changed `handleCustomTypeToJson()` to be useful

### DIFF
--- a/vertx-jooq-async-generate/src/main/java/io/github/jklingsporn/vertx/jooq/async/generate/AbstractVertxGenerator.java
+++ b/vertx-jooq-async-generate/src/main/java/io/github/jklingsporn/vertx/jooq/async/generate/AbstractVertxGenerator.java
@@ -230,7 +230,7 @@ public abstract class AbstractVertxGenerator extends JavaGenerator {
      * @return <code>true</code> if the column was handled.
      * @see #generateToJson(TableDefinition, JavaWriter)
      */
-    protected boolean handleCustomTypeToJson(TypedElementDefinition<?> column, String getter, String columnType, String javaMemberName, JavaWriter out) {
+    protected boolean handleCustomTypeToJson(ColumnDefinition column, String getter, String columnType, String javaMemberName, JavaWriter out) {
         return false;
     }
 


### PR DESCRIPTION
As demonstrated in `generateToJson()`, in order to call `json.put()` correctly we need the "json name". `generateToJson()` calls `getJsonName()` to get the json name, which takes a `ColumnDefinition`. Implementations of `handleCustomTypeToJson()` only get the super type of `ColumnDefinition` and must down-cast to call `getJsonName()`.

As `generateToJson()` is the only caller of `handleCustomTypeToJson()`, its definition can match how it is called.